### PR TITLE
update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,5 @@
   "scripts": {
     "test": "node test/test-crypto.js"
   },
-  "licenses": [{
-    "type" : "BSD",
-    "url" : "http://pajhome.org.uk/site/legal.html#bsdlicense"
-  }]
+  "license": "BSD-3-Clause"
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/
