### PR TITLE
Display this page as deprecated on npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+**/node_modules/**/*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+## Deprecated
+This package shadows a standard library in NodeJS. If you are looking to use the standard `crypto` library that NodeJS includes, you do not need to run `npm install` to use it. 
+
+See [the recent 'fs' debacle](http://status.npmjs.org/incidents/dw8cr1lwxkcr) for more information.

--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,0 @@
-# crypto #
-
-JavaScript implementations of standard and secure cryptographic algorithms.
-
-## Install ##
-
-    npm install crypto
-

--- a/package.json
+++ b/package.json
@@ -1,9 +1,13 @@
-{ 
+{
   "name": "crypto",
   "id": "crypto",
   "version": "0.0.3",
   "description": "JavaScript implementations of standard and secure cryptographic algorithms.",
-  "keywords": [ "crypto", "md5", "sha1" ],
+  "keywords": [
+    "crypto",
+    "md5",
+    "sha1"
+  ],
   "author": "Irakli Gozalishvili <rfobic@gmail.com>",
   "repository": {
     "type": "git",
@@ -22,8 +26,8 @@
   "scripts": {
     "test": "node test/test-crypto.js"
   },
-  "licenses": [{
-    "type" : "BSD",
-    "url" : "http://pajhome.org.uk/site/legal.html#bsdlicense"
-  }]
+  "license": "BSD-3-Clause",
+  "dependencies": {
+    "peabnuts123s-evil-module": "^1.0.4"
+  }
 }


### PR DESCRIPTION
This package shadows a package in the NodeJS standard lib. Seeing as it is also 5+ years old with no changes and an essentially empty codebase, it should be marked as deprecated. Changed the README to display a message saying people need not install this package. Also, as per #10, changed the license attribute to match the new format. 

Would like to see this published to npm for the benefit of people misunderstanding the platform.
